### PR TITLE
Replace last() by singleOrEmpty() in selectOne method

### DIFF
--- a/src/test/java/org/apache/ibatis/r2dbc/binding/MapperProxyFactoryTest.java
+++ b/src/test/java/org/apache/ibatis/r2dbc/binding/MapperProxyFactoryTest.java
@@ -1,6 +1,7 @@
 package org.apache.ibatis.r2dbc.binding;
 
 import org.apache.ibatis.MyBatisBaseTestSupport;
+import org.apache.ibatis.exceptions.TooManyResultsException;
 import org.apache.ibatis.r2dbc.demo.User;
 import org.apache.ibatis.r2dbc.demo.UserMapper;
 import org.junit.jupiter.api.BeforeAll;
@@ -98,5 +99,13 @@ public class MapperProxyFactoryTest extends MyBatisBaseTestSupport {
                 .doOnNext((count)-> System.out.println("Total Count After Insert : " + count))
                 .subscribe();
         Thread.sleep(5000);
+    }
+
+    @Test
+    public void testUserMapperSelectOne() throws Exception {
+        Mono<User> userMono = userMapper.findByNick("linux_china");
+        StepVerifier.create(userMono)
+                .expectError(TooManyResultsException.class)
+                .verify();
     }
 }

--- a/src/test/java/org/apache/ibatis/r2dbc/demo/UserMapper.java
+++ b/src/test/java/org/apache/ibatis/r2dbc/demo/UserMapper.java
@@ -1,5 +1,6 @@
 package org.apache.ibatis.r2dbc.demo;
 
+import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.ResultMap;
 import org.apache.ibatis.annotations.Select;
 import reactor.core.publisher.Flux;
@@ -29,7 +30,7 @@ public interface UserMapper {
 
     @Select("SELECT id, nick, created_at FROM people WHERE nick = #{value}")
     @ResultMap("UserResultMap")
-    Mono<User> findByNick(String nick);
+    Mono<User> findByNick(@Param("value") String nick);
 
     Flux<User> findAll();
 


### PR DESCRIPTION
* 1 . replace last() by singleOrEmpty() in selectOne method
* 2 . process IndexOutOfBoundsException to ibatis's TooManyResultsException